### PR TITLE
[ISSUE-21] Implement a new option to back up an output folder on failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,6 @@ test-results
 /Logs/
 /*.noindex/
 /TestResults/
-fastlane/test_output/
+fastlane/test_output*
 /info.plist
 *.xcuserdatad

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Under the hood `try_scan` uses official [`fastlane scan action`](https://docs.fa
 | parallel_workers | Specify the exact number of test runners that will be spawned during parallel testing. Equivalent to `-parallel-testing-worker-count` and `concurrent_workers` |  |
 | retry_build | Should building be retried after failure? | false |
 | retry_strategy | What would you like to retry after failure: test, class or suite? | test |
+| backup | Back up an output of each execution to a separate folder | false |
 
 ## Requirements
 

--- a/lib/fastlane/plugin/try_scan/actions/try_scan_action.rb
+++ b/lib/fastlane/plugin/try_scan/actions/try_scan_action.rb
@@ -85,6 +85,14 @@ module Fastlane
               possible_strategies = ['test', 'class', 'suite']
               UI.user_error!("Error: :retry_strategy must equal to one of the following values: #{possible_strategies}") unless possible_strategies.include?(strategy)
             end
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :backup,
+            env_name: "FL_TRY_SCAN_BACKUP",
+            description: "Back up an output of each execution to a separate folder",
+            is_string: false,
+            optional: true,
+            default_value: false
           )
         ]
       end

--- a/lib/fastlane/plugin/try_scan/helper/scan_helper.rb
+++ b/lib/fastlane/plugin/try_scan/helper/scan_helper.rb
@@ -66,6 +66,27 @@ module TryScanManager
           end
         end
       end
+
+      def self.backup_output_folder(attempt)
+        output_files = report_options.instance_variable_get(:@output_files)
+        output_directory = report_options.instance_variable_get(:@output_directory)
+
+        unless output_files.empty?
+          FastlaneCore::UI.verbose("Back up an output folder")
+          backup = "#{output_directory}_#{attempt}"
+          FileUtils.mkdir_p(backup)
+          FileUtils.copy_entry(output_directory, backup)
+        end
+      end
+
+      def self.clean_up_backup
+        output_directory = report_options.instance_variable_get(:@output_directory)
+
+        Dir["#{output_directory}_*"].each do |backup|
+          FastlaneCore::UI.verbose("Removing backup: #{backup}")
+          FileUtils.rm_rf(backup)
+        end
+      end
     end
   end
 end

--- a/lib/fastlane/plugin/try_scan/helper/try_scan_runner.rb
+++ b/lib/fastlane/plugin/try_scan/helper/try_scan_runner.rb
@@ -11,6 +11,7 @@ module TryScanManager
     def run
       configure_xcargs
       prepare_scan_config(@options)
+      FastlaneScanHelper.clean_up_backup
       print_summary
       @attempt = 1
       begin
@@ -22,6 +23,7 @@ module TryScanManager
       rescue FastlaneCore::Interface::FastlaneTestFailure => _
         failed_tests = failed_tests_from_xcresult_report
         print_try_scan_result(failed_tests_count: failed_tests.size)
+        backup_output_folder if @options[:backup]
         return false if finish?
 
         @attempt += 1
@@ -192,6 +194,10 @@ module TryScanManager
 
     def tests_count_from_xcresult_report
       parse_xcresult_report['metrics']['testsCount']['_value']
+    end
+
+    def backup_output_folder
+      FastlaneScanHelper.backup_output_folder(@attempt)
     end
   end
 end

--- a/lib/fastlane/plugin/try_scan/version.rb
+++ b/lib/fastlane/plugin/try_scan/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module TryScan
-    VERSION = "1.0.1"
+    VERSION = "1.0.2"
   end
 end


### PR DESCRIPTION
# Changes
- Implement `backup` option to back up an output folder on failure

## References
- https://github.com/alteral/fastlane-plugin-try_scan/issues/21

## Risks
- [ ] None
- [x] Low
- [ ] High
