### PR TITLE
Bump some dependency versions

### DIFF
--- a/fastlane-plugin-try_scan.gemspec
+++ b/fastlane-plugin-try_scan.gemspec
@@ -26,9 +26,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('pry')
   spec.add_development_dependency('bundler')
   spec.add_development_dependency('rake')
-  spec.add_development_dependency('fasterer', '0.8.3')
+  spec.add_development_dependency('fasterer', '0.9.0')
   spec.add_development_dependency('rubocop', '0.49.1')
   spec.add_development_dependency('rubocop-require_tools')
   spec.add_development_dependency('simplecov')
-  spec.add_development_dependency('fastlane', '>= 2.144.0')
+  spec.add_development_dependency('fastlane', '>= 2.188.0')
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,12 +1,14 @@
 lane :test do
   try_scan(
     try_count: 2,
-    scheme: 'sample-appSuccessfulTests'
+    scheme: 'sample-appSuccessfulTests',
+    backup: true
   )
 
   try_scan(
     try_count: 10,
-    scheme: 'sample-appParallelUITests'
+    scheme: 'sample-appParallelUITests',
+    backup: false
   )
 
   try_scan(


### PR DESCRIPTION
# Changes
- bump `fastlane` and `fasterer` versions
- add `backup` option in the tests

## Risks
- [x] None
- [ ] Low
- [ ] High
